### PR TITLE
Publish Ollama and Postgres ports on host loopback

### DIFF
--- a/deploy/docker/docker-compose.postgresql-external.ollama-openai.local.yml
+++ b/deploy/docker/docker-compose.postgresql-external.ollama-openai.local.yml
@@ -59,6 +59,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.postgresql-external.ollama-openai.yml
+++ b/deploy/docker/docker-compose.postgresql-external.ollama-openai.yml
@@ -53,6 +53,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.postgresql-external.ollama.local.yml
+++ b/deploy/docker/docker-compose.postgresql-external.ollama.local.yml
@@ -60,6 +60,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.postgresql-external.ollama.yml
+++ b/deploy/docker/docker-compose.postgresql-external.ollama.yml
@@ -57,6 +57,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.postgresql.ollama-openai.local.yml
+++ b/deploy/docker/docker-compose.postgresql.ollama-openai.local.yml
@@ -66,6 +66,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1
@@ -139,6 +143,11 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg18-trixie
+    # Publish PostgreSQL on the host loopback so host tools (e.g. pgAdmin) can
+    # connect at 127.0.0.1:5432; not exposed to the LAN. Credentials default to
+    # postgres/postgres -- keep this loopback-only unless you change them.
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRESQL_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD:-postgres}

--- a/deploy/docker/docker-compose.postgresql.ollama-openai.yml
+++ b/deploy/docker/docker-compose.postgresql.ollama-openai.yml
@@ -60,6 +60,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1
@@ -133,6 +137,11 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg18-trixie
+    # Publish PostgreSQL on the host loopback so host tools (e.g. pgAdmin) can
+    # connect at 127.0.0.1:5432; not exposed to the LAN. Credentials default to
+    # postgres/postgres -- keep this loopback-only unless you change them.
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRESQL_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD:-postgres}

--- a/deploy/docker/docker-compose.postgresql.ollama.local.yml
+++ b/deploy/docker/docker-compose.postgresql.ollama.local.yml
@@ -67,6 +67,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1
@@ -148,6 +152,11 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg18-trixie
+    # Publish PostgreSQL on the host loopback so host tools (e.g. pgAdmin) can
+    # connect at 127.0.0.1:5432; not exposed to the LAN. Credentials default to
+    # postgres/postgres -- keep this loopback-only unless you change them.
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRESQL_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD:-postgres}

--- a/deploy/docker/docker-compose.postgresql.ollama.yml
+++ b/deploy/docker/docker-compose.postgresql.ollama.yml
@@ -64,6 +64,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1
@@ -145,6 +149,11 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg18-trixie
+    # Publish PostgreSQL on the host loopback so host tools (e.g. pgAdmin) can
+    # connect at 127.0.0.1:5432; not exposed to the LAN. Credentials default to
+    # postgres/postgres -- keep this loopback-only unless you change them.
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRESQL_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD:-postgres}

--- a/deploy/docker/docker-compose.postgresql.openai.yml
+++ b/deploy/docker/docker-compose.postgresql.openai.yml
@@ -60,6 +60,11 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg18-trixie
+    # Publish PostgreSQL on the host loopback so host tools (e.g. pgAdmin) can
+    # connect at 127.0.0.1:5432; not exposed to the LAN. Credentials default to
+    # postgres/postgres -- keep this loopback-only unless you change them.
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRESQL_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRESQL_PASSWORD:-postgres}

--- a/deploy/docker/docker-compose.sqlite.ollama-openai.local.yml
+++ b/deploy/docker/docker-compose.sqlite.ollama-openai.local.yml
@@ -58,6 +58,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.sqlite.ollama-openai.yml
+++ b/deploy/docker/docker-compose.sqlite.ollama-openai.yml
@@ -52,6 +52,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.sqlite.ollama.local.yml
+++ b/deploy/docker/docker-compose.sqlite.ollama.local.yml
@@ -59,6 +59,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1

--- a/deploy/docker/docker-compose.sqlite.ollama.yml
+++ b/deploy/docker/docker-compose.sqlite.ollama.yml
@@ -56,6 +56,10 @@ services:
     # For AMD ROCm GPU (Linux host only), use the ROCm-tagged image instead:
     # image: ollama/ollama:rocm
     pull_policy: always
+    # Publish Ollama on the host loopback so host-side tools (e.g. Code Review
+    # Graph) can reach it at http://127.0.0.1:11434; not exposed to the LAN.
+    ports:
+      - "127.0.0.1:11434:11434"
     environment:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_KEEP_ALIVE=-1


### PR DESCRIPTION
Publish the containerized Ollama (11434) and embedded Postgres (5432) ports to the host so host-side tools such as pgAdmin and the Code Review Graph can reach the services directly.

Bind to 127.0.0.1 so the services are reachable from the host but not exposed to the LAN, which matters because the embedded Postgres ships default postgres/postgres credentials.

The server's existing 8000 port is unchanged.