### PR TITLE
docs: replace the dynamic license badge with a static Elastic License 2.0 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src=".github/images/banner.png" alt="MCP Context Server - MCP-based server providing persistent multimodal context storage for LLM agents" width="100%">
 </p>
 
-[![PyPI](https://img.shields.io/pypi/v/mcp-context-server.svg)](https://pypi.org/project/mcp-context-server/) [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-blue?logo=anthropic)](https://registry.modelcontextprotocol.io/?q=io.github.alex-feel%2Fmcp-context-server) [![GitHub License](https://img.shields.io/github/license/alex-feel/mcp-context-server)](https://github.com/alex-feel/mcp-context-server/blob/main/LICENSE) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alex-feel/mcp-context-server)
+[![PyPI](https://img.shields.io/pypi/v/mcp-context-server.svg)](https://pypi.org/project/mcp-context-server/) [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-blue?logo=anthropic)](https://registry.modelcontextprotocol.io/?q=io.github.alex-feel%2Fmcp-context-server) [![License: Elastic License 2.0](https://img.shields.io/badge/license-Elastic_2.0-blue)](https://github.com/alex-feel/mcp-context-server/blob/main/LICENSE) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alex-feel/mcp-context-server)
 
 A high-performance Model Context Protocol (MCP) server providing persistent multimodal context storage for LLM agents. Built with FastMCP, this server enables seamless context sharing across multiple agents working on the same task through thread-based scoping.
 


### PR DESCRIPTION
GitHub license detection does not recognize the Elastic License 2.0 because it is absent from the choosealicense corpus, so the GitHub API reports the license as unidentifiable and the dynamic shields.io badge rendered as invalid. A static badge states the license explicitly, keeps the same link to the LICENSE file, and cannot regress with upstream detection changes.